### PR TITLE
adding can-reflect-tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "can-symbol": "^1.6.4"
   },
   "devDependencies": {
+    "can-reflect-tests": "^0.3.1",
     "detect-cyclic-packages": "^1.1.0",
     "fixpack": "^2.3.1",
     "http-server": "^0.11.1",

--- a/test/test.js
+++ b/test/test.js
@@ -1,2 +1,3 @@
 require("./define-class-test");
 require("./define-test");
+require("./type-events-test");

--- a/test/type-events-test.js
+++ b/test/type-events-test.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const QUnit = require("steal-qunit");
+const Defined = require("../can-define-class");
+
+QUnit.module("can-define-class Type events");
+
+require("can-reflect-tests/observables/map-like/type/type")("Defined", function(){
+	return class Type extends Defined {};
+});


### PR DESCRIPTION
Closes https://github.com/canjs/can-define-class/issues/24.
Closes https://github.com/canjs/can-define-class/issues/21.
Still need to handle https://github.com/canjs/can-define-class/issues/22.
Also, need to figure out if other symbols from https://github.com/canjs/can-define/blob/c3ea493a6a13587b679ac51077a8124c8c67280d/map/map.js#L206-L266 are needed.