### PR TITLE
Support JS setters and getters

### DIFF
--- a/define.js
+++ b/define.js
@@ -72,7 +72,7 @@ function defineConfigurableAndNotEnumerable(obj, prop, value) {
 }
 
 function eachPropertyDescriptor(map, cb){
-	for(var prop in map) {
+	for(var prop of Object.getOwnPropertyNames(map)) {
 		if(map.hasOwnProperty(prop)) {
 			cb.call(map, prop, Object.getOwnPropertyDescriptor(map,prop));
 		}
@@ -297,8 +297,7 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 
 	// If property has a getter, create the compute that stores its data.
 	if (definition.get) {
-		throw new Error("'get' is not a valid option");
-		//computedInitializers[prop] = make.compute(prop, definition.get, getInitialValue);
+		computedInitializers[prop] = make.compute(prop, definition.get, getInitialValue);
 	}
 	else if (definition.async) {
 		computedInitializers[prop] = make.compute(prop, callAsync(definition.async), getInitialValue);
@@ -875,8 +874,7 @@ getDefinitionsAndMethods = function(defines, baseDefines, typePrototype) {
 		defaultDefinition = Object.create(null);
 	}
 
-	eachPropertyDescriptor(defines, function( prop, propertyDescriptor ) {
-
+	function addDefinition(prop, propertyDescriptor) {
 		var value;
 		if(propertyDescriptor.get || propertyDescriptor.set) {
 			value = {get: propertyDescriptor.get, set: propertyDescriptor.set};
@@ -907,7 +905,10 @@ getDefinitionsAndMethods = function(defines, baseDefines, typePrototype) {
 				//!steal-remove-end
 			}
 		}
-	});
+	}
+
+	eachPropertyDescriptor(typePrototype, addDefinition);
+	eachPropertyDescriptor(defines, addDefinition);
 	if(defaults) {
 		// we should move this property off the prototype.
 		defineConfigurableAndNotEnumerable(defines,"*", defaults);

--- a/test/define-class-test.js
+++ b/test/define-class-test.js
@@ -160,6 +160,8 @@ QUnit.test("JavaScript setters work", function(assert) {
 	assert.equal(faves.color, "blue", "Did not change");
 });
 
+// Note that this is not documented behavior so we can change it in the future if needed
+// It's unlikely something someone would do on purpose anyways.
 QUnit.test("Setters on the define override those on the prototype", function(assert) {
 	class Faves extends Defined {
 		static get define() {

--- a/test/define-class-test.js
+++ b/test/define-class-test.js
@@ -145,7 +145,7 @@ QUnit.test("Does not throw if no define is provided", function(assert) {
 	assert.ok(true, "Did not throw");
 });
 
-QUnit.skip("JavaScript setters work", function(assert) {
+QUnit.test("JavaScript setters work", function(assert) {
 	class Faves extends Defined {
 		static get define() {
 			return {};
@@ -158,6 +158,34 @@ QUnit.skip("JavaScript setters work", function(assert) {
 	let faves = new Faves();
 	faves.color = "red";
 	assert.equal(faves.color, "blue", "Did not change");
+});
+
+QUnit.test("Setters on the define override those on the prototype", function(assert) {
+	class Faves extends Defined {
+		static get define() {
+			return {
+				color: {
+					enumerable: false,
+					set(v) {
+						return "green";
+					}
+				}
+			};
+		}
+		set color(v) {
+			return "blue";
+		}
+	}
+
+	let faves = new Faves();
+	faves.color = "red";
+	assert.equal(faves.color, "green", "Changed to green");
+
+	let props = [];
+	for(let prop in faves) {
+		props.push(prop);
+	}
+	assert.deepEqual(props, [], "Not enumerable too");
 });
 
 QUnit.test("set() can return a different value", function(assert) {


### PR DESCRIPTION
This makes it so that both JS setters and getters work, with those in
the `define {}` taking priority if both exist.

Closes #17 and #10