### PR TITLE
Prevent the default function from being used as the defaults

### DIFF
--- a/can-define-class.js
+++ b/can-define-class.js
@@ -67,7 +67,8 @@ function define(Base = Object) {
 		static _initDefines() {
 			if(!this[hasBeenDefinedSymbol]) {
 				let prototypeObject = this.prototype;
-				let defines = this.define;
+				// Won't be necessary if we do https://github.com/canjs/can-define-class/issues/46
+				let defines = this.define !== define ? this.define : {};
 				addDefinedProps(prototypeObject, defines);
 				this[hasBeenDefinedSymbol] = true;
 			}


### PR DESCRIPTION
Because we have `DefineClass.define()` as a mixin, if you don't provide
a `static define` it will attend to use the define() mixins as the
defines.

This fixes that. Is a temporary need.