### PR TITLE
Allow providing an object as the default

### DIFF
--- a/define.js
+++ b/define.js
@@ -799,13 +799,13 @@ make = {
 define.behaviors = ["get", "set", "value", "Value", "type", "Type", "serialize"];
 
 // This cleans up a particular behavior and adds it to the definition
-var addBehaviorToDefinition = function(definition, behavior, value) {
+var addBehaviorToDefinition = function(definition, behavior, descriptor, def) {
 	if(behavior === "enumerable") {
 		// treat enumerable like serialize
-		definition.serialize = !!value;
+		definition.serialize = !!def[behavior];
 	}
 	else if(behavior === "type") {
-		var behaviorDef = value;
+		var behaviorDef = def[behavior];
 		if(typeof behaviorDef === "string") {
 			behaviorDef = define.types[behaviorDef];
 			if(typeof behaviorDef === "object" && !isDefineType(behaviorDef)) {
@@ -818,7 +818,7 @@ var addBehaviorToDefinition = function(definition, behavior, value) {
 		}
 	}
 	else {
-		definition[behavior] = value;
+		definition[behavior] = descriptor.get || descriptor.value;
 	}
 };
 
@@ -828,8 +828,8 @@ var addBehaviorToDefinition = function(definition, behavior, value) {
 makeDefinition = function(prop, def, defaultDefinition/*, typePrototype*/) {
 	var definition = {};
 
-	canReflect.eachKey(def, function(value, behavior) {
-		addBehaviorToDefinition(definition, behavior, value);
+	eachPropertyDescriptor(def, function(behavior, descriptor) {
+		addBehaviorToDefinition(definition, behavior, descriptor, def);
 	});
 	// only add default if it doesn't exist
 	canReflect.eachKey(defaultDefinition, function(value, prop){

--- a/test/define-class-test.js
+++ b/test/define-class-test.js
@@ -379,3 +379,23 @@ QUnit.test("Extended DefineClasses can be used to set the type", function(assert
 		assert.ok(true, "Throws because it is a strict type")
 	}
 });
+
+QUnit.test("Allow a default object to be provided by using a getter", function(assert) {
+	class Thing extends Defined {
+		static get define() {
+			return {
+				prop: {
+					get default() {
+						return { foo: "bar" };
+					}
+				}
+			}
+		}
+	}
+
+	let one = new Thing();
+	let two = new Thing();
+
+	assert.deepEqual(one.prop, { foo: "bar" }, "Sets the default");
+	assert.notEqual(one.prop, two.prop, "Different instances");
+});


### PR DESCRIPTION
This allows a property to have an object as the default by using a
getter.

```js
class Thing extends DefineClass {
  static define = {
    prop: {
      get default() {
        return { foo: 'bar' };
      }
    }
  }
}
```

Closes #39